### PR TITLE
fix: wrong variable type

### DIFF
--- a/src/mod_zone_difficulty_scripts.cpp
+++ b/src/mod_zone_difficulty_scripts.cpp
@@ -59,7 +59,7 @@ void ZoneDifficulty::LoadMapDifficultySettings()
         {
             if ((*result)[2].Get<bool>())
             {
-                sZoneDifficulty->SpellNerfOverrides[(*result)[0].Get<uint32>()] = (*result)[1].Get<uint32>();
+                sZoneDifficulty->SpellNerfOverrides[(*result)[0].Get<uint32>()] = (*result)[1].Get<float>();
             }
 
         } while (result->NextRow());


### PR DESCRIPTION
Variable in the map is defined as float, and so is the column in the table.