### PR TITLE
 fix: health scaling for <100%hp mobs and `UNIT_MOD_HEALTH` changes

### DIFF
--- a/src/mod_zone_difficulty_scripts.cpp
+++ b/src/mod_zone_difficulty_scripts.cpp
@@ -1108,22 +1108,24 @@ public:
             newHp = round(baseHealth * multiplier);
         }
 
+        float value = newHp;
+        value *= creature->GetModifierValue(UNIT_MOD_HEALTH, BASE_PCT);
+        value += creature->GetModifierValue(UNIT_MOD_HEALTH, TOTAL_VALUE);
+        value *= creature->GetModifierValue(UNIT_MOD_HEALTH, TOTAL_PCT);
+
         if (matchingPhase != -1)
         {
-            if (creature->GetMaxHealth() == newHp)
+            if (creature->GetMaxHealth() == value)
                 return;
 
-            bool hpIsFull = false;
-
-            if (creature->GetHealthPct() >= 100)
-                hpIsFull = true;
-
-            creature->SetMaxHealth(newHp);
-            creature->SetCreateHealth(newHp);
+            float percent = creature->GetHealthPct();
             creature->SetModifierValue(UNIT_MOD_HEALTH, BASE_VALUE, (float)newHp);
-            if (hpIsFull)
-                creature->SetHealth(newHp);
-            creature->UpdateAllStats();
+            creature->UpdateMaxHealth();
+            if (creature->IsAlive())
+            {
+                uint32 scaledCurHealth = creature->CountPctFromMaxHealth(percent);
+                creature->SetHealth(scaledCurHealth);
+            }
             creature->ResetPlayerDamageReq();
         }
     }


### PR DESCRIPTION
## Changes
- guard check now properly compares base health + modifiers with max health
- some refactor to avoid confusion with base health, max health, etc.
- some calls are not needed
  - removed creature->SetCreateHealth(newHp);
  - removed creature->SetMaxHealth(newHp);
  - removed SetCreateHealth(newHp);
- changed UpdateAllStats to UpdateMaxHealth
- IsAlive() check to avoid setting health to 0 https://github.com/azerothcore/azerothcore-wotlk/blob/6fd034c8b3038a967e17136ece47df13009e1d68/src/server/game/Spells/Auras/SpellAuraEffects.cpp#L4791

previous attempt
- https://github.com/azerothcore/mod-zone-difficulty/pull/49

## Closes
- https://github.com/azerothcore/mod-zone-difficulty/issues/48
- https://github.com/chromiecraft/chromiecraft/issues/7501
- https://github.com/chromiecraft/chromiecraft/issues/7485

## Test
tested with custom core branch https://github.com/sogladev/azerothcore-wotlk/tree/module-zone-difficulty-hp-test 
- speed up kael'thas
- BT reliquary, remove adds and speed up transition time 

module DB changes:
```
-- TK
INSERT INTO zone_difficulty_mythicmode_creatureoverrides (CreatureEntry, HPModifier, HPModifierNormal, Enabled, Comment) VALUES
(20064, 5.0, 5.0, 1, 'Test Thaladred advisor');
-- BWL
UPDATE zone_difficulty_info SET Enabled=1 WHERE MapID=469;
INSERT INTO zone_difficulty_mythicmode_creatureoverrides (CreatureEntry, HPModifier, HPModifierNormal, Enabled, Comment) VALUES(13020, 5, 10, 1, 'Vaelastraz test');
-- BT
UPDATE zone_difficulty_mythicmode_creatureoverrides SET HPModifier=5.0, HPModifierNormal=5.0 WHERE CreatureEntry = 23419;
```

1. go to BWL, see if Vael is ~30% hp `.go c id 13020`
2. Kael, kill advisors then wait for resurrection. see if hp is scaled for Thaladred (warrior axe) and 100% hp
```
.go c id 19622
.cheat god
.damage 300000
Nefarian's Barrier - CC immune
.cast 22663
```
3. BT Relinquary https://github.com/chromiecraft/chromiecraft/issues/7485#issuecomment-2471910668
  first mob that is spawned scaled more, debug conditional breakpoint in  `(creature->GetEntry() == 23419) && (creature->GetHealth() != creature->GetMaxHealth())` `mod_zone_difficulty_scripts.cpp:1113` if breakpoint hits then bug should no longer occur