### PR TITLE
fix: CI module build cppcheck

### DIFF
--- a/src/ZoneDifficulty.h
+++ b/src/ZoneDifficulty.h
@@ -9,15 +9,15 @@
 
 struct ZoneDifficultyNerfData
 {
-    float HealingNerfPct;
-    float AbsorbNerfPct;
-    float SpellDamageBuffPct;
-    float MeleeDamageBuffPct;
-    int8 Enabled;
-    float HealingNerfPctHard;
-    float AbsorbNerfPctHard;
-    float SpellDamageBuffPctHard;
-    float MeleeDamageBuffPctHard;
+    float HealingNerfPct = 1.0f;
+    float AbsorbNerfPct = 1.0f;
+    float SpellDamageBuffPct = 1.0f;
+    float MeleeDamageBuffPct = 1.0f;
+    int8 Enabled = 1;
+    float HealingNerfPctHard = 1.0f;
+    float AbsorbNerfPctHard = 1.0f;
+    float SpellDamageBuffPctHard = 1.0f;
+    float MeleeDamageBuffPctHard = 1.0f;
 };
 
 struct ZoneDifficulySpellOverrideData
@@ -66,8 +66,8 @@ struct VendorSelectionData
 
 struct CreatureOverrideData
 {
-    float NormalOverride;
-    float MythicOverride;
+    float NormalOverride = 1.0f;
+    float MythicOverride = 1.0f;
 };
 
 int32 const DUEL_INDEX = 0x7FFFFFFF;

--- a/src/mod_zone_difficulty_handler.cpp
+++ b/src/mod_zone_difficulty_handler.cpp
@@ -45,6 +45,10 @@ void ZoneDifficulty::LoadMapDifficultySettings()
     NerfInfo[DUEL_INDEX][0].AbsorbNerfPct = 1;
     NerfInfo[DUEL_INDEX][0].MeleeDamageBuffPct = 1;
     NerfInfo[DUEL_INDEX][0].SpellDamageBuffPct = 1;
+    NerfInfo[DUEL_INDEX][0].HealingNerfPctHard = 1;
+    NerfInfo[DUEL_INDEX][0].AbsorbNerfPctHard = 1;
+    NerfInfo[DUEL_INDEX][0].MeleeDamageBuffPctHard = 1;
+    NerfInfo[DUEL_INDEX][0].SpellDamageBuffPctHard = 1;
 
     // Heroic Quest -> MapId Translation
     HeroicTBCQuestMapList[542] = 11362; // Blood Furnace


### PR DESCRIPTION
fixes module build errors due to failing cppcheck https://github.com/azerothcore/mod-zone-difficulty/actions/runs/12699226019/job/35399414259
```
[1mmodules/mod-zone-difficulty/src/mod_zone_difficulty_handler.cpp:123:63: [31merror:[39m Uninitialized variables: data.HealingNerfPctHard, data.AbsorbNerfPctHard, data.SpellDamageBuffPctHard, data.MeleeDamageBuffPctHard [uninitvar][0m
                sZoneDifficulty->NerfInfo[mapId][phaseMask] = data;
                                                              ^
[1mmodules/mod-zone-difficulty/src/mod_zone_difficulty_handler.cpp:242:69: [31mwarning:[39m Uninitialized variables: data.NormalOverride, data.MythicOverride [uninitvar][0m
                sZoneDifficulty->CreatureOverrides[creatureEntry] = data;
...
```

changes:
initialize variables by setting default values

default values from tables:
https://github.com/azerothcore/mod-zone-difficulty/blob/0e0b1850cd1a2ee3bc669b89eb5270c67236346b/data/sql/db-world/zone_difficulty_info.sql#L5
https://github.com/azerothcore/mod-zone-difficulty/blob/0e0b1850cd1a2ee3bc669b89eb5270c67236346b/data/sql/db-world/zone_difficulty_mythicmode_creatureoverrides.sql#L4

## Test
Run cppcheck from CI locally
https://github.com/azerothcore/reusable-workflows/blob/main/.github/workflows/core_build_modules.yml

```
cppcheck --force --inline-suppr --suppressions-list=cppchecksuppressions.txt --output-file=report.txt modules/
```
https://github.com/azerothcore/reusable-workflows/blob/4de2039354f9ac4565f6a079196f8b33f2e2a93e/cppchecksuppressions.txt#L2
