### PR TITLE
fix: patch update when loading NerfInfo

### DIFF
--- a/src/mod_zone_difficulty_handler.cpp
+++ b/src/mod_zone_difficulty_handler.cpp
@@ -127,7 +127,11 @@ void ZoneDifficulty::LoadMapDifficultySettings()
                 data.MeleeDamageBuffPct = (*result)[4].Get<float>();
                 data.SpellDamageBuffPct = (*result)[5].Get<float>();
                 data.Enabled = data.Enabled | mode;
-                sZoneDifficulty->NerfInfo[mapId][phaseMask] = data;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].HealingNerfPct = data.HealingNerfPct;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].AbsorbNerfPct = data.AbsorbNerfPct;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].MeleeDamageBuffPct = data.MeleeDamageBuffPct;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].SpellDamageBuffPct = data.SpellDamageBuffPct;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].Enabled |= mode;
             }
             if (sZoneDifficulty->HasMythicmode(mode) && sZoneDifficulty->MythicmodeEnable)
             {
@@ -136,7 +140,11 @@ void ZoneDifficulty::LoadMapDifficultySettings()
                 data.MeleeDamageBuffPctHard = (*result)[4].Get<float>();
                 data.SpellDamageBuffPctHard = (*result)[5].Get<float>();
                 data.Enabled = data.Enabled | mode;
-                sZoneDifficulty->NerfInfo[mapId][phaseMask] = data;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].HealingNerfPctHard = data.HealingNerfPctHard;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].AbsorbNerfPctHard = data.AbsorbNerfPctHard;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].MeleeDamageBuffPctHard = data.MeleeDamageBuffPctHard;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].SpellDamageBuffPctHard = data.SpellDamageBuffPctHard;
+                sZoneDifficulty->NerfInfo[mapId][phaseMask].Enabled |= mode;
             }
             if ((mode & MODE_HARD) != MODE_HARD && (mode & MODE_NORMAL) != MODE_NORMAL)
             {


### PR DESCRIPTION
When loading Normal/Mythic only patch Normal/Mythic fields ZoneDifficultyNerfData.

Previous: loading normal/mythic sets ZoneDifficultyNerfData with default mythic/normal values

- https://github.com/azerothcore/mod-zone-difficulty/blob/af4724c40b59a455929e57a9163a51a6da852846/src/ZoneDifficulty.h#L10

Fixes regression caused by
- https://github.com/azerothcore/mod-zone-difficulty/pull/60

