### PR TITLE
Correct AuraEffectList type

### DIFF
--- a/src/mod_zone_difficulty_scripts.cpp
+++ b/src/mod_zone_difficulty_scripts.cpp
@@ -56,7 +56,7 @@ public:
 
                     if (spellInfo->HasAura(SPELL_AURA_SCHOOL_ABSORB))
                     {
-                        std::list<AuraEffect*> AuraEffectList = target->GetAuraEffectsByType(SPELL_AURA_SCHOOL_ABSORB);
+                        Unit::AuraEffectList const& AuraEffectList = target->GetAuraEffectsByType(SPELL_AURA_SCHOOL_ABSORB);
 
                         for (AuraEffect* eff : AuraEffectList)
                         {


### PR DESCRIPTION
Compile fix for AC PR https://github.com/azerothcore/azerothcore-wotlk/pull/22584

This can be merged regardless of AC PR status, as this just uses the properly defined typedef.